### PR TITLE
Fix the way/generators version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "laracasts/flash": "~1.3"
     },
     "require-dev": {
-        "way/generators": "dev-feature/laravel-five-stable",
+        "way/generators": "~3.0",
         "doctrine/dbal": "~2.4"
     },
     "autoload": {


### PR DESCRIPTION
This fixes the generators import. technically the generators for l5 are located at https://github.com/laracasts/Laravel-5-Generators-Extended, not sure if these can be used.
